### PR TITLE
Add "POS" functionality to the $whohas command

### DIFF
--- a/HAL9666/AuctionMasterBot.py
+++ b/HAL9666/AuctionMasterBot.py
@@ -486,11 +486,17 @@ async def updateInventory(groupId: str, inventory: dict[str, dict[str,int]]):
       inventory[row["Username"]][row["Ticker"]] = 0
     inventory[row["Username"]][row["Ticker"]] += int(row["Amount"])
 
-async def findInInventory(ticker: str, inventory: dict[str, dict[str,int]])->list[tuple[str, int]]:
+async def findInInventory(ticker: str, inventory: dict[str, dict[str,int]], shouldReturnAll: bool = False)->list[tuple[str, int]]:
   result: list[tuple[str, int]] = []
   for (user, inv) in inventory.items():
     if ticker in inv:
       result.append((user, inv[ticker]))
+
+  if not shouldReturnAll:
+    sellers = getSellers(ticker)
+    print("Sellers:", str(sellers))
+    result = [(u, a) for (u, a) in result if u in sellers]
+
   return sorted(result, key=lambda x: x[1])[::-1]
 
 
@@ -507,7 +513,7 @@ def getSellers(ticker: str) -> list[str]:
     ]
   return result
 
-async def whohas(ctx: Any, ticker: str, shouldReturnAll: bool) -> list[tuple[str, int]]:
+async def whohas(ctx: Any, ticker: str, shouldReturnAll: bool = False) -> list[tuple[str, int]]:
   
   Log.info("whohas", ticker)
 
@@ -525,13 +531,9 @@ async def whohas(ctx: Any, ticker: str, shouldReturnAll: bool) -> list[tuple[str
         "Error updating inventory from FIO. Falling back to cached data"
     )
   
-  result = await findInInventory(ticker, inventory)
+  result = await findInInventory(ticker, inventory, shouldReturnAll)
   #print(str(result))
   print("Full:", str(result))
-  if not shouldReturnAll:
-    sellers = getSellers(ticker)
-    print("Sellers:", str(sellers))
-    result = [(u, a) for (u, a) in result if u in sellers]
 
   return result
 

--- a/HAL9666/AuctionMasterBot.py
+++ b/HAL9666/AuctionMasterBot.py
@@ -28,8 +28,8 @@ CachedSellersData:  Iterable[dict[str, str]] = {}
 FioInventoryUrl = "https://rest.fnar.net/csv/inventory?group={group}&apikey={apikey}"
 FioInventoryShipyardGroup = "41707164"
 FioInventoryEv1lGroup = "83373923"
-CachedShipyardInventories: dict[str, dict[str, int]] = {}
-CachedEv1lInventories: dict[str, dict[str, int]] = {}
+CachedShipyardInventories: dict[str, dict[str, tuple[str,int]]] = {}
+CachedEv1lInventories: dict[str, dict[str, tuple[str,int]]] = {}
 ShipPartTickers = (
     "BR1",
     "BR2",  #bridges
@@ -468,7 +468,7 @@ async def help(ctx):
       "$bid [price]\nPlaces a new bid. Examples:\n$bid 4mil\nbid 4.25mil\n")
   await ctx.send("$status\nShows current auction status")
 
-async def updateInventory(groupId: str, inventory: dict[str, dict[str,int]]):
+async def updateInventory(groupId: str, inventory: dict[str, dict[str,list[tuple[str,int]]]]):
   fioUrl = FioInventoryUrl.format(
       apikey=os.getenv("FIO_API_KEY"),
       group=groupId)
@@ -483,34 +483,56 @@ async def updateInventory(groupId: str, inventory: dict[str, dict[str,int]]):
     if row["Username"] not in inventory:
       inventory[row["Username"]] = {}
     if row["Ticker"] not in inventory[row["Username"]]:
-      inventory[row["Username"]][row["Ticker"]] = 0
-    inventory[row["Username"]][row["Ticker"]] += int(row["Amount"])
+      inventory[row["Username"]][row["Ticker"]] = []
+    inventory[row["Username"]][row["Ticker"]].append((row["NaturalId"], int(row["Amount"])))
 
-async def findInInventory(ticker: str, inventory: dict[str, dict[str,int]], shouldReturnAll: bool = False)->list[tuple[str, int]]:
-  result: list[tuple[str, int]] = []
+async def findInInventory(ticker: str, inventory: dict[str, dict[str,list[tuple[str,int]]]], shouldReturnAll: bool = False)->list[tuple[str, int]]:
+  result: list[tuple[str, list[tuple[str,int]]]] = []
+  # filter for only ticker we want
   for (user, inv) in inventory.items():
     if ticker in inv:
       result.append((user, inv[ticker]))
 
   if not shouldReturnAll:
-    sellers = getSellers(ticker)
+    sellersData = getSellerData(ticker)
+    sellers = [s for s in sellersData.keys()]
     print("Sellers:", str(sellers))
-    result = [(u, a) for (u, a) in result if u in sellers]
+    seller_filtered_result = [x for x in result if x[0] in sellers]
 
-  return sorted(result, key=lambda x: x[1])[::-1]
+    pos_filtered_result: list[tuple[str,list[tuple[str,int]]]] = []
+
+    for (user, inv_rows) in seller_filtered_result:
+      filtered_inv_rows = [x for x in inv_rows if x[0] in sellersData[user] or len(sellersData[user]) == 0]
+      if len(filtered_inv_rows) > 0:
+        pos_filtered_result.append((user, filtered_inv_rows))
+
+    result = pos_filtered_result
+      
+  summed_inventories: list[tuple[str,int]] = []
+  # sum up amounts from all remaining locations
+  for (user, inv_rows) in result:
+    amount = sum([x[1] for x in inv_rows])
+    if amount > 0:
+      summed_inventories.append((user, amount))
 
 
-def getSellers(ticker: str) -> list[str]:
+
+  return sorted(summed_inventories, key=lambda x: x[1])[::-1]
+
+
+def getSellerData(ticker: str) -> dict[str,list[str]]:
   global CachedSellersData
-  result: list[str] = []
+  result = {}
   response = requests.get(OfferingsCsvUrl)
   if response.status_code == 200:
-    CachedSellersData = csv.DictReader(response.text.split("\r\n"))
+    CachedSellersData = list(csv.DictReader(response.text.split("\r\n")))
   if CachedSellersData:
-    result = [
-        row["Seller"].upper() for row in CachedSellersData
-        if row["MAT"] == ticker
-    ]
+    result: dict[str,list[str]] = {}
+    for row in CachedSellersData:
+      pos_list = [x for x in row.get("POS", "").split(',') if x != ""]
+      if row["MAT"] == ticker:
+        result[row['Seller'].upper()] = pos_list
+
   return result
 
 async def whohas(ctx: Any, ticker: str, shouldReturnAll: bool = False) -> list[tuple[str, int]]:
@@ -526,7 +548,7 @@ async def whohas(ctx: Any, ticker: str, shouldReturnAll: bool = False) -> list[t
   inventory = CachedShipyardInventories if isShipPartTicker else CachedEv1lInventories
   try:
     await updateInventory(groupId=group, inventory=inventory)
-  except Exception:
+  except Exception as e:
     await ctx.reply(
         "Error updating inventory from FIO. Falling back to cached data"
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,6 +11,11 @@ python = "^3.10"
 requests = "^2.31.0"
 
 
+[tool.poetry.group.dev.dependencies]
+pytest = "^7.4.3"
+pytest-asyncio = "^0.21.1"
+asynctest = "^0.13.0"
+
 [build-system]
 requires = ["poetry-core"]
 build-backend = "poetry.core.masonry.api"

--- a/test/test_inventory.py
+++ b/test/test_inventory.py
@@ -1,0 +1,129 @@
+from unittest.mock import MagicMock
+from asynctest import CoroutineMock
+import pytest
+import csv
+import HAL9666.AuctionMasterBot as bot
+import io
+
+@pytest.mark.asyncio
+async def test_inventory():
+
+    general_csv_file = create_csv(
+        [
+            {"Username":"Kindling", "Ticker": "C", "Amount":"200", "NaturalId": "UV-351a"}
+        ]
+    )
+
+    shipyard_csv_file = create_csv(
+        [
+            {"Username":"Felmer", "Ticker": "WCB", "Amount":"3", "NaturalId": "UV-351a"}
+        ]
+    ) 
+    
+    fake_fio_response = MagicMock()
+    fake_fio_response.status_code = 200
+    fake_fio_response.text = general_csv_file
+
+    bot.requests.get = MagicMock(return_value=fake_fio_response)
+
+    bot.getSellerData = MagicMock(return_value = {"Kindling":[], "Felmer": [], "Gilith": []})
+
+    inv = await bot.whohas(CoroutineMock(), "C")
+    assert inv[0] == ("Kindling", 200)
+
+    general_csv_file = create_csv(
+        [
+            {"Username":"Kindling", "Ticker": "C", "Amount":"200", "NaturalId": "UV-351a"},
+            {"Username":"Felmer", "Ticker": "C", "Amount":"250", "NaturalId": "UV-351a"}
+        ]
+    )
+    fake_fio_response.text = general_csv_file
+
+    inv = await bot.whohas(CoroutineMock(), "C")
+
+    assert inv[0] == ("Felmer", 250)
+    assert inv[1] == ("Kindling", 200)
+
+    fake_fio_response.status_code = 500
+
+    ctx = MagicMock()
+    ctx.reply = CoroutineMock()
+    inv = await bot.whohas(ctx, "C")
+
+    assert inv[0] == ("Felmer", 250)
+    assert inv[1] == ("Kindling", 200)
+
+    fake_fio_response.status_code = 200
+    fake_fio_response.text = shipyard_csv_file
+    inv = await bot.whohas(ctx, "WCB")
+
+    assert len(inv) == 1
+    assert inv[0] == ("Felmer", 3)
+
+    fake_fio_response.status_code = 500
+    inv = await bot.whohas(ctx, "C")
+
+    assert inv[0] == ("Felmer", 250)
+    assert inv[1] == ("Kindling", 200)
+
+@pytest.mark.asyncio
+async def test_pos_filter():
+
+    # when someone has set POS filter, we should only count the amounts from those locations
+    bot.getSellerData = MagicMock(return_value = {"Kindling":["UV-351a"], "Felmer": ["XG-521b"], "Gilith": []})
+
+    csv_file = create_csv(
+        [
+            {"Username":"Kindling", "Ticker": "C", "Amount":"200", "NaturalId": "UV-351a"},
+            {"Username":"Kindling", "Ticker": "C", "Amount":"100", "NaturalId": "KW-688c"},
+            {"Username":"Gilith", "Ticker": "C", "Amount":"100", "NaturalId": "UV-351a"},
+            {"Username":"Felmer", "Ticker": "C", "Amount":"250", "NaturalId": "UV-351a"}
+        ]
+    )
+    
+    fio_response = MagicMock()
+    fio_response.status_code = 200
+    fio_response.text = csv_file
+
+    bot.requests.get = MagicMock(return_value=fio_response)
+
+    inv = await bot.whohas(MagicMock(), "C", False)
+
+    assert len(inv) == 2
+    assert inv[0] == ("Kindling", 200)
+    assert inv[1] == ("Gilith", 100)
+
+
+# TODO: test shouldReturnAll = False
+
+def test_getSellersData():
+    csv_data = [
+            {"MAT":"C", "Seller": "Kindling", "POS":"KW-688c", "Price/u": "300"},
+            {"MAT":"C", "Seller": "Felmer", "POS":"", "Price/u": "300"},
+            {"MAT":"WCB", "Seller": "Felmer", "POS":"UV-351a", "Price/u": "300000"}
+        ]
+    sheets_csv_file = create_csv(csv_data)
+
+    fake_fio_response = MagicMock()
+    fake_fio_response.status_code = 200
+    fake_fio_response.text = sheets_csv_file
+    bot.requests.get = MagicMock(return_value = fake_fio_response)
+
+    sellers = bot.getSellerData("C")
+
+    assert isinstance(sellers, dict)
+    assert len(sellers) == 2
+
+    sellers = bot.getSellerData("WCB")
+    assert len(sellers) == 1
+
+def create_csv(csv_data: list[dict[str,str]]) -> str:
+    if len(csv_data) < 1: raise ValueError("List must have atleast 1 entry")
+
+    csv_file = io.StringIO()
+    general_csv_writer = csv.DictWriter(csv_file, list(csv_data[0].keys()))
+    general_csv_writer.writeheader()
+    for row in csv_data:
+        general_csv_writer.writerow(row)
+
+    return csv_file.getvalue()


### PR DESCRIPTION
I had some fun over the weekend, and made a stab at making a "POS" filter for the $whohas command.

It works by checking a "POS" column in the offers sheet for a comma separated list of "NaturalIds" (no mapping between Names and Ids for now).
If there exists a POS column, and that column is not empty, we filter FIO inventory data to only count amounts at the listed locations.

Example:
Kindling has 1000 C on EW, and 500 C on Deimos. This is what will get reported from FIO
Kindling does not want the $whohas command to show the Deimos inventory, b.c it's not for sale, it's for smelting.
So they add "KW-688c" to the POS column for their C offfer row.

Now when someone asks $whohas C, it will respond with "KINDLING has 1000 C"

If they would have left the POS column empty, it would have responded with "KINDLING has 1500 C"
If they would have put [KW-688c,ZV-759c] in the POS column, it would also respond with 1500 C

I felt I needed to add some tests in order to not introduce tons of bugs, and to make testing a bit easier, I needed to refactor some of the functions into smaller pieces.
I also added some typing info to the functions I worked with. Also to make it a little easier to deal with all the transformations of the various lists and dicts and tuples we throw around.
I hope this actually makes it easier to continue work on for others as well. If this just made everything more confusing, please point me in the direction you'd like this to go, and I'll refactor towards that.