### PR TITLE
Some refactoring and cleanup

### DIFF
--- a/HAL9666/AuctionMasterBot.py
+++ b/HAL9666/AuctionMasterBot.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python3
 
-from typing import Any, Iterable
+from typing import Any
 import discord
 from discord.ext import commands
 
 import asyncio
-import csv
 from datetime import datetime
 from datetime import timedelta
 import logging
 import os
-import requests
 
 import traceback
+
+from HAL9666.lib.inventory import whohas
 
 #from keep_alive_flask import keep_alive
 intents = discord.Intents.default()
@@ -29,67 +29,7 @@ ValidChannels = ("auction", "auction-bot-sandbox")
 #set to True for debugging
 ShortenHoursToMinutes = False
 
-#corp spreadsheet exported as CSV
-OfferingsCsvUrl = "https://docs.google.com/spreadsheets/d/e/2PACX-1vTU0PDYV0CYk5LObZAFcxIXZNshT27WHvy1CZNmm8paC7eMVmTlCk3rxIFyEY6Tbiz0uiIDG8CxGuCm/pub?gid=0&single=true&output=csv"
-CachedSellersData:  Iterable[dict[str, str]] = {}
 
-FioInventoryUrl = "https://rest.fnar.net/csv/inventory?group={group}&apikey={apikey}"
-FioInventoryShipyardGroup = "41707164"
-FioInventoryEv1lGroup = "83373923"
-CachedShipyardInventories: dict[str, dict[str, list[tuple[str,int]]]] = {}
-CachedEv1lInventories: dict[str, dict[str, list[tuple[str,int]]]] = {}
-ShipPartTickers = (
-    "BR1",
-    "BR2",  #bridges
-    "CQT",
-    "CQS",
-    "CQM",
-    "CQL",  #crew q
-    "FFC",
-    "SFE",
-    "MFE",
-    "LFE",  #FFC, emitters
-    "GEN",
-    "ENG",
-    "FSE",
-    "AEN",
-    "HTE",  #STL engines
-    "RCT",
-    "QCR",
-    "HPR",
-    "HYR",  #FTL engines
-    "SSL",
-    "MSL",
-    "LSL",  #STL fuel tanks
-    "SFL",
-    "MFL",
-    "LFL",  #FTL fuel tanks
-    "TCB",
-    "VSC",
-    "SCB",
-    "MCB",
-    "LCB",
-    "WCB",
-    "VCB",  #cargo bays
-    "SSC",
-    "LHB",
-    "BHP",
-    "RHP",
-    "HHP",
-    "AHP",  #hull plates, SSC
-    "BGS",
-    "AGS",
-    "STS",  #misc
-    "BPT",
-    "APT",
-    "BWH",
-    "AWH",  #whipple shields and thermal protection
-    "RDS",
-    "RDL",  #repair drones
-    "BRP",
-    "ARP",
-    "SRP"  #anti-radiation plates
-)
 
 currentAuction = None
 Log = logging.getLogger(__name__)
@@ -466,97 +406,6 @@ async def help(ctx):
   await ctx.send(
       "$bid [price]\nPlaces a new bid. Examples:\n$bid 4mil\nbid 4.25mil\n")
   await ctx.send("$status\nShows current auction status")
-
-def updateInventory(groupId: str, inventory: dict[str, dict[str,list[tuple[str,int]]]]):
-  fioUrl = FioInventoryUrl.format(
-      apikey=os.getenv("FIO_API_KEY"),
-      group=groupId)
-  response = requests.get(fioUrl)
-  if response.status_code != 200:
-    raise Exception(f"Failed to update inventory for groupId {groupId}")
-
-  csvData = csv.DictReader(response.text.split("\r\n"))
-
-  inventory.clear()
-  for row in csvData:
-    if row["Username"] not in inventory:
-      inventory[row["Username"]] = {}
-    if row["Ticker"] not in inventory[row["Username"]]:
-      inventory[row["Username"]][row["Ticker"]] = []
-    inventory[row["Username"]][row["Ticker"]].append((row["NaturalId"], int(row["Amount"])))
-
-def findInInventory(ticker: str, inventory: dict[str, dict[str,list[tuple[str,int]]]], shouldReturnAll: bool = False)->list[tuple[str, int]]:
-  result: list[tuple[str, list[tuple[str,int]]]] = []
-  # filter for only ticker we want
-  for (user, inv) in inventory.items():
-    if ticker in inv:
-      result.append((user, inv[ticker]))
-
-  if not shouldReturnAll:
-    sellersData = getSellerData(ticker)
-    sellers = [s for s in sellersData.keys()]
-    print("Sellers:", str(sellers))
-    seller_filtered_result = [x for x in result if x[0] in sellers]
-
-    pos_filtered_result: list[tuple[str,list[tuple[str,int]]]] = []
-
-    for (user, inv_rows) in seller_filtered_result:
-      filtered_inv_rows = [x for x in inv_rows if x[0] in sellersData[user] or len(sellersData[user]) == 0]
-      if len(filtered_inv_rows) > 0:
-        pos_filtered_result.append((user, filtered_inv_rows))
-
-    result = pos_filtered_result
-      
-  summed_inventories: list[tuple[str,int]] = []
-  # sum up amounts from all remaining locations
-  for (user, inv_rows) in result:
-    amount = sum([x[1] for x in inv_rows])
-    if amount > 0:
-      summed_inventories.append((user, amount))
-
-
-
-  return sorted(summed_inventories, key=lambda x: x[1])[::-1]
-
-
-def getSellerData(ticker: str) -> dict[str,list[str]]:
-  global CachedSellersData
-  result = {}
-  response = requests.get(OfferingsCsvUrl)
-  if response.status_code == 200:
-    CachedSellersData = list(csv.DictReader(response.text.split("\r\n")))
-  if CachedSellersData:
-    result: dict[str,list[str]] = {}
-    for row in CachedSellersData:
-      pos_list = [x.strip() for x in row.get("POS", "").split(',') if x != ""]
-      if row["MAT"] == ticker:
-        result[row['Seller'].upper()] = pos_list
-
-  return result
-
-async def whohas(ctx: Any, ticker: str, shouldReturnAll: bool = False) -> list[tuple[str, int]]:
-  
-  Log.info("whohas", ticker)
-
-  # update relevant group inventory
-  global CachedShipyardInventories
-  global CachedEv1lInventories
-  isShipPartTicker = ticker in ShipPartTickers
-
-  group = FioInventoryShipyardGroup if isShipPartTicker else FioInventoryEv1lGroup
-  inventory = CachedShipyardInventories if isShipPartTicker else CachedEv1lInventories
-  try:
-    updateInventory(groupId=group, inventory=inventory)
-  except Exception as e:
-    await ctx.reply(
-        "Error updating inventory from FIO. Falling back to cached data"
-    )
-  
-  result = findInInventory(ticker, inventory, shouldReturnAll)
-  #print(str(result))
-  print("Full:", str(result))
-
-  return result
 
 
 @bot.command(name="whohas")

--- a/HAL9666/lib/inventory.py
+++ b/HAL9666/lib/inventory.py
@@ -1,0 +1,162 @@
+import csv
+import logging
+import os
+from typing import Iterable, Any
+
+import requests
+
+Log = logging.getLogger(__name__)
+
+#corp spreadsheet exported as CSV
+OfferingsCsvUrl = "https://docs.google.com/spreadsheets/d/e/2PACX-1vTU0PDYV0CYk5LObZAFcxIXZNshT27WHvy1CZNmm8paC7eMVmTlCk3rxIFyEY6Tbiz0uiIDG8CxGuCm/pub?gid=0&single=true&output=csv"
+CachedSellersData:  Iterable[dict[str, str]] = {}
+
+FioInventoryUrl = "https://rest.fnar.net/csv/inventory?group={group}&apikey={apikey}"
+FioInventoryShipyardGroup = "41707164"
+FioInventoryEv1lGroup = "83373923"
+CachedShipyardInventories: dict[str, dict[str, list[tuple[str,int]]]] = {}
+CachedEv1lInventories: dict[str, dict[str, list[tuple[str,int]]]] = {}
+ShipPartTickers = (
+    "BR1",
+    "BR2",  #bridges
+    "CQT",
+    "CQS",
+    "CQM",
+    "CQL",  #crew q
+    "FFC",
+    "SFE",
+    "MFE",
+    "LFE",  #FFC, emitters
+    "GEN",
+    "ENG",
+    "FSE",
+    "AEN",
+    "HTE",  #STL engines
+    "RCT",
+    "QCR",
+    "HPR",
+    "HYR",  #FTL engines
+    "SSL",
+    "MSL",
+    "LSL",  #STL fuel tanks
+    "SFL",
+    "MFL",
+    "LFL",  #FTL fuel tanks
+    "TCB",
+    "VSC",
+    "SCB",
+    "MCB",
+    "LCB",
+    "WCB",
+    "VCB",  #cargo bays
+    "SSC",
+    "LHB",
+    "BHP",
+    "RHP",
+    "HHP",
+    "AHP",  #hull plates, SSC
+    "BGS",
+    "AGS",
+    "STS",  #misc
+    "BPT",
+    "APT",
+    "BWH",
+    "AWH",  #whipple shields and thermal protection
+    "RDS",
+    "RDL",  #repair drones
+    "BRP",
+    "ARP",
+    "SRP"  #anti-radiation plates
+)
+
+
+def updateInventory(groupId: str, inventory: dict[str, dict[str, list[tuple[str, int]]]]):
+    fioUrl = FioInventoryUrl.format(
+        apikey=os.getenv("FIO_API_KEY"),
+        group=groupId)
+    response = requests.get(fioUrl)
+    if response.status_code != 200:
+        raise Exception(f"Failed to update inventory for groupId {groupId}")
+
+    csvData = csv.DictReader(response.text.split("\r\n"))
+
+    inventory.clear()
+    for row in csvData:
+        if row["Username"] not in inventory:
+            inventory[row["Username"]] = {}
+        if row["Ticker"] not in inventory[row["Username"]]:
+            inventory[row["Username"]][row["Ticker"]] = []
+        inventory[row["Username"]][row["Ticker"]].append((row["NaturalId"], int(row["Amount"])))
+
+
+def findInInventory(ticker: str, inventory: dict[str, dict[str, list[tuple[str, int]]]],
+                    shouldReturnAll: bool = False) -> list[tuple[str, int]]:
+    result: list[tuple[str, list[tuple[str, int]]]] = []
+    # filter for only ticker we want
+    for (user, inv) in inventory.items():
+        if ticker in inv:
+            result.append((user, inv[ticker]))
+
+    if not shouldReturnAll:
+        sellersData = getSellerData(ticker)
+        sellers = [s for s in sellersData.keys()]
+        print("Sellers:", str(sellers))
+        seller_filtered_result = [x for x in result if x[0] in sellers]
+
+        pos_filtered_result: list[tuple[str, list[tuple[str, int]]]] = []
+
+        for (user, inv_rows) in seller_filtered_result:
+            filtered_inv_rows = [x for x in inv_rows if x[0] in sellersData[user] or len(sellersData[user]) == 0]
+            if len(filtered_inv_rows) > 0:
+                pos_filtered_result.append((user, filtered_inv_rows))
+
+        result = pos_filtered_result
+
+    summed_inventories: list[tuple[str, int]] = []
+    # sum up amounts from all remaining locations
+    for (user, inv_rows) in result:
+        amount = sum([x[1] for x in inv_rows])
+        if amount > 0:
+            summed_inventories.append((user, amount))
+
+    return sorted(summed_inventories, key=lambda x: x[1])[::-1]
+
+
+def getSellerData(ticker: str) -> dict[str, list[str]]:
+    global CachedSellersData
+    result = {}
+    response = requests.get(OfferingsCsvUrl)
+    if response.status_code == 200:
+        CachedSellersData = list(csv.DictReader(response.text.split("\r\n")))
+    if CachedSellersData:
+        result: dict[str, list[str]] = {}
+        for row in CachedSellersData:
+            pos_list = [x.strip() for x in row.get("POS", "").split(',') if x != ""]
+            if row["MAT"] == ticker:
+                result[row['Seller'].upper()] = pos_list
+
+    return result
+
+
+async def whohas(ctx: Any, ticker: str, shouldReturnAll: bool = False) -> list[tuple[str, int]]:
+    Log.info("whohas", ticker)
+
+    # update relevant group inventory
+    global CachedShipyardInventories
+    global CachedEv1lInventories
+    isShipPartTicker = ticker in ShipPartTickers
+
+    group = FioInventoryShipyardGroup if isShipPartTicker else FioInventoryEv1lGroup
+    inventory = CachedShipyardInventories if isShipPartTicker else CachedEv1lInventories
+    try:
+        updateInventory(groupId=group, inventory=inventory)
+    except Exception as e:
+        await ctx.reply(
+            "Error updating inventory from FIO. Falling back to cached data"
+        )
+
+    result = findInInventory(ticker, inventory, shouldReturnAll)
+    # print(str(result))
+    print("Full:", str(result))
+
+    return result

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,7 +14,6 @@ requests = "^2.31.0"
 [tool.poetry.group.dev.dependencies]
 pytest = "^7.4.3"
 pytest-asyncio = "^0.21.1"
-asynctest = "^0.13.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/test/test_inventory.py
+++ b/test/test_inventory.py
@@ -1,131 +1,135 @@
-from unittest.mock import MagicMock, patch
-from asynctest import CoroutineMock
+from unittest.mock import MagicMock, AsyncMock, patch
 import pytest
 import csv
-import HAL9666.AuctionMasterBot as bot
 import io
 
-@pytest.mark.asyncio
-@patch('HAL9666.AuctionMasterBot.getSellerData')
-async def test_inventory(mock_getSellerData):
+from HAL9666.lib.inventory import getSellerData, whohas
 
-    general_csv_stream = create_csv(
-        [
-            {"Username":"Kindling", "Ticker": "C", "Amount":"200", "NaturalId": "UV-351a"}
-        ]
-    )
-
-    shipyard_csv_stream = create_csv(
-        [
-            {"Username":"Felmer", "Ticker": "WCB", "Amount":"3", "NaturalId": "UV-351a"}
-        ]
-    ) 
-    
-    fake_fio_response = MagicMock()
-    fake_fio_response.status_code = 200
-    fake_fio_response.text = general_csv_stream
-
-    bot.requests.get = MagicMock(return_value=fake_fio_response)
-
-    mock_getSellerData.return_value = {"Kindling":[], "Felmer": [], "Gilith": []}
-
-    inv = await bot.whohas(CoroutineMock(), "C")
-    assert inv[0] == ("Kindling", 200)
-
-    general_csv_stream = create_csv(
-        [
-            {"Username":"Kindling", "Ticker": "C", "Amount":"200", "NaturalId": "UV-351a"},
-            {"Username":"Felmer", "Ticker": "C", "Amount":"250", "NaturalId": "UV-351a"}
-        ]
-    )
-    fake_fio_response.text = general_csv_stream
-
-    inv = await bot.whohas(CoroutineMock(), "C")
-
-    assert inv[0] == ("Felmer", 250)
-    assert inv[1] == ("Kindling", 200)
-
-    fake_fio_response.status_code = 500
-
-    ctx = MagicMock()
-    ctx.reply = CoroutineMock()
-    inv = await bot.whohas(ctx, "C")
-
-    assert inv[0] == ("Felmer", 250)
-    assert inv[1] == ("Kindling", 200)
-
-    fake_fio_response.status_code = 200
-    fake_fio_response.text = shipyard_csv_stream
-    inv = await bot.whohas(ctx, "WCB")
-
-    assert len(inv) == 1
-    assert inv[0] == ("Felmer", 3)
-
-    fake_fio_response.status_code = 500
-    inv = await bot.whohas(ctx, "C")
-
-    assert inv[0] == ("Felmer", 250)
-    assert inv[1] == ("Kindling", 200)
 
 @pytest.mark.asyncio
-@patch('HAL9666.AuctionMasterBot.getSellerData')
-async def test_pos_filter(mock_getSellerData):
+@patch('HAL9666.lib.inventory.requests.get')
+@patch('HAL9666.lib.inventory.getSellerData')
+async def test_inventory(mock_getSellerData, requests_get):
+  general_csv_stream = create_csv(
+    [
+      {"Username": "Kindling", "Ticker": "C", "Amount": "200", "NaturalId": "UV-351a"}
+    ]
+  )
 
-    # when someone has set POS filter, we should only count the amounts from those locations
-    mock_getSellerData.return_value = {"Kindling":["UV-351a"], "Felmer": ["XG-521b"], "Gilith": []}
+  shipyard_csv_stream = create_csv(
+    [
+      {"Username": "Felmer", "Ticker": "WCB", "Amount": "3", "NaturalId": "UV-351a"}
+    ]
+  )
 
-    csv_stream = create_csv(
-        [
-            {"Username":"Kindling", "Ticker": "C", "Amount":"200", "NaturalId": "UV-351a"},
-            {"Username":"Kindling", "Ticker": "C", "Amount":"100", "NaturalId": "KW-688c"},
-            {"Username":"Gilith", "Ticker": "C", "Amount":"100", "NaturalId": "UV-351a"},
-            {"Username":"Felmer", "Ticker": "C", "Amount":"250", "NaturalId": "UV-351a"}
-        ]
-    )
-    
-    fio_response = MagicMock()
-    fio_response.status_code = 200
-    fio_response.text = csv_stream
+  fake_fio_response = MagicMock()
+  fake_fio_response.status_code = 200
+  fake_fio_response.text = general_csv_stream
 
-    bot.requests.get = MagicMock(return_value=fio_response)
+  requests_get.return_value = fake_fio_response
 
-    inv = await bot.whohas(MagicMock(), "C", False)
+  mock_getSellerData.return_value = {"Kindling": [], "Felmer": [], "Gilith": []}
 
-    assert len(inv) == 2
-    assert ("Kindling", 200) in inv
-    assert ("Gilith", 100) in inv
+  inv = await (whohas(AsyncMock(), "C"))
+  assert inv[0] == ("Kindling", 200)
+
+  general_csv_stream = create_csv(
+    [
+      {"Username": "Kindling", "Ticker": "C", "Amount": "200", "NaturalId": "UV-351a"},
+      {"Username": "Felmer", "Ticker": "C", "Amount": "250", "NaturalId": "UV-351a"}
+    ]
+  )
+  fake_fio_response.text = general_csv_stream
+
+  inv = await whohas(AsyncMock(), "C")
+
+  assert inv[0] == ("Felmer", 250)
+  assert inv[1] == ("Kindling", 200)
+
+  fake_fio_response.status_code = 500
+
+  ctx = MagicMock()
+  ctx.reply = AsyncMock()
+  inv = await whohas(ctx, "C")
+
+  assert inv[0] == ("Felmer", 250)
+  assert inv[1] == ("Kindling", 200)
+
+  fake_fio_response.status_code = 200
+  fake_fio_response.text = shipyard_csv_stream
+  inv = await whohas(ctx, "WCB")
+
+  assert len(inv) == 1
+  assert inv[0] == ("Felmer", 3)
+
+  fake_fio_response.status_code = 500
+  inv = await whohas(ctx, "C")
+
+  assert inv[0] == ("Felmer", 250)
+  assert inv[1] == ("Kindling", 200)
+
+
+@pytest.mark.asyncio
+@patch('HAL9666.lib.inventory.requests.get')
+@patch('HAL9666.lib.inventory.getSellerData')
+async def test_pos_filter(mock_getSellerData, requests_get):
+  # when someone has set POS filter, we should only count the amounts from those locations
+  mock_getSellerData.return_value = {"Kindling": ["UV-351a"], "Felmer": ["XG-521b"], "Gilith": []}
+
+  csv_stream = create_csv(
+    [
+      {"Username": "Kindling", "Ticker": "C", "Amount": "200", "NaturalId": "UV-351a"},
+      {"Username": "Kindling", "Ticker": "C", "Amount": "100", "NaturalId": "KW-688c"},
+      {"Username": "Gilith", "Ticker": "C", "Amount": "100", "NaturalId": "UV-351a"},
+      {"Username": "Felmer", "Ticker": "C", "Amount": "250", "NaturalId": "UV-351a"}
+    ]
+  )
+
+  fio_response = MagicMock()
+  fio_response.status_code = 200
+  fio_response.text = csv_stream
+
+  requests_get.return_value = fio_response
+
+  inv = await whohas(MagicMock(), "C", False)
+
+  assert len(inv) == 2
+  assert ("Kindling", 200) in inv
+  assert ("Gilith", 100) in inv
 
 
 # TODO: test shouldReturnAll = False
 
-def test_getSellersData():
-    csv_data = [
-            {"MAT":"C", "Seller": "Kindling", "POS":"KW-688c", "Price/u": "300"},
-            {"MAT":"C", "Seller": "Felmer", "POS":"", "Price/u": "300"},
-            {"MAT":"WCB", "Seller": "Felmer", "POS":"UV-351a", "Price/u": "300000"}
-        ]
-    sheets_csv_stream = create_csv(csv_data)
+@patch('HAL9666.lib.inventory.requests.get')
+def test_getSellersData(requests_get):
+  csv_data = [
+    {"MAT": "C", "Seller": "Kindling", "POS": "KW-688c", "Price/u": "300"},
+    {"MAT": "C", "Seller": "Felmer", "POS": "", "Price/u": "300"},
+    {"MAT": "WCB", "Seller": "Felmer", "POS": "UV-351a", "Price/u": "300000"}
+  ]
+  sheets_csv_stream = create_csv(csv_data)
 
-    fake_fio_response = MagicMock()
-    fake_fio_response.status_code = 200
-    fake_fio_response.text = sheets_csv_stream
-    bot.requests.get = MagicMock(return_value = fake_fio_response)
+  fake_fio_response = MagicMock()
+  fake_fio_response.status_code = 200
+  fake_fio_response.text = sheets_csv_stream
+  requests_get.return_value = fake_fio_response
 
-    sellers = bot.getSellerData("C")
+  sellers = getSellerData("C")
 
-    assert isinstance(sellers, dict)
-    assert len(sellers) == 2
+  assert isinstance(sellers, dict)
+  assert len(sellers) == 2
 
-    sellers = bot.getSellerData("WCB")
-    assert len(sellers) == 1
+  sellers = getSellerData("WCB")
+  assert len(sellers) == 1
 
-def create_csv(csv_data: list[dict[str,str]]) -> str:
-    if len(csv_data) < 1: raise ValueError("List must have atleast 1 entry")
 
-    csv_stream = io.StringIO()
-    general_csv_writer = csv.DictWriter(csv_stream, list(csv_data[0].keys()))
-    general_csv_writer.writeheader()
-    for row in csv_data:
-        general_csv_writer.writerow(row)
+def create_csv(csv_data: list[dict[str, str]]) -> str:
+  if len(csv_data) < 1: raise ValueError("List must have atleast 1 entry")
 
-    return csv_stream.getvalue()
+  csv_stream = io.StringIO()
+  general_csv_writer = csv.DictWriter(csv_stream, list(csv_data[0].keys()))
+  general_csv_writer.writeheader()
+  for row in csv_data:
+    general_csv_writer.writerow(row)
+
+  return csv_stream.getvalue()


### PR DESCRIPTION
- Replace external CoroutineMock with builtin AsyncMock.
- Use `patch` for the mocking of requests.get() too. This should make the tests independent now.
- Moved all the inventory stuff to its own module to make the main bot module less cluttered.
- Pycharm insisted on reformatting the test file to 2 spaces, I guess since the bot module was already using that. PEP8 complains though...

Closes #10 (by actually patching instead of just replacing the get method in the module during testing)