### PR TITLE
Background fetch + some other improvements

### DIFF
--- a/HAL9666/AuctionMasterBot.py
+++ b/HAL9666/AuctionMasterBot.py
@@ -11,7 +11,7 @@ from typing import Any
 import discord
 from discord.ext import commands
 
-from HAL9666.lib.inventory import whohas
+from HAL9666.lib.inventory import fetch_inventory_data_periodically, whohas
 
 # from keep_alive_flask import keep_alive
 intents = discord.Intents.default()
@@ -435,7 +435,7 @@ async def help(ctx):
 
 
 @bot.command(name="whohas")
-async def whohas_command(ctx: Any, ticker: str, all: str = ""):
+async def whohas_command(ctx: Any, ticker: str, all: str = "", force: str = ""):
     if ctx.author == bot.user or ctx.author.bot:
         return
     if ctx.channel.name not in ValidChannels:
@@ -445,9 +445,10 @@ async def whohas_command(ctx: Any, ticker: str, all: str = ""):
         return
 
     shouldReturnAll = all.lower() == "all"
+    forceUpdate = force.lower() == "force" or all.lower() == "force" #  force ends up in "all" if "$whohas FE force"
 
     result = await whohas(
-        ctx=ctx, ticker=ticker.upper(), shouldReturnAll=shouldReturnAll
+        ctx=ctx, ticker=ticker.upper(), shouldReturnAll=shouldReturnAll, forceUpdate=forceUpdate
     )
 
     if len(result) == 0:
@@ -471,6 +472,10 @@ async def clearchannel(ctx):
     await ctx.channel.purge()
 
 
+async def main():
+    await fetch_inventory_data_periodically()
+    await bot.start(os.getenv("DISCORD_TOKEN"))
+
 # keep_alive()
 if __name__ == "__main__":
-    bot.run(os.getenv("DISCORD_TOKEN"))
+    asyncio.run(main())

--- a/HAL9666/lib/inventory.py
+++ b/HAL9666/lib/inventory.py
@@ -42,6 +42,7 @@ class GroupInventory:
             raise Exception(f"Retries exhausted. Failed to update inventory for group {self.group_name} (id:{self.group_id})")
         else:
             Log.info(f"Retrying fetch for group {self.group_name}")
+
         if response.status_code == 200:
             Log.info(f"Updated FIO inventory for group {self.group_name}")
         elif response.status_code == 429:
@@ -51,7 +52,7 @@ class GroupInventory:
             #  if this call was a 429, we don't want to fall through to the actual update after this
             #  That is handled by whatever retry call gets a 200 response
             return
-        elif response.status_code != 200:
+        else:
             raise Exception(
                 f"Failed to update inventory for group {self.group_name} (id:{self.group_id})"
             )
@@ -127,7 +128,7 @@ class SellerData:
         )
         if response.status_code == 307:
             Log.info(f"Got a temporary rediret")
-        if response.status_code == 200:
+        elif response.status_code == 200:
             self.data = list(csv.DictReader(response.text.split("\r\n")))
             self.last_updated = datetime.now()
             Log.info(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,9 +6,10 @@ authors = ["Your Name <you@example.com>"]
 readme = "README.md"
 
 [tool.poetry.dependencies]
-python = "^3.10"
+python = "^3.9"
 "discord.py" = "^2.3.2"
-requests = "^2.31.0"
+httpx = "^0.25.2"
+asyncio-periodic = "^2019.2"
 
 
 [tool.poetry.group.dev.dependencies]

--- a/test/test_inventory.py
+++ b/test/test_inventory.py
@@ -38,7 +38,7 @@ async def test_inventory(mock_seller_data, async_client):
     mock_seller_data.update = AsyncMock()
     mock_seller_data.get_sellers_for_ticker = MagicMock(return_value={"Kindling": [], "Felmer": [], "Gilith": []})
 
-    inv = await whohas(AsyncMock(), "C", forceUpdate=True)
+    inv, last_updated = await whohas(AsyncMock(), "C", forceUpdate=True)
     assert inv[0] == ("Kindling", 200)
 
     general_csv_stream = create_csv(
@@ -59,7 +59,7 @@ async def test_inventory(mock_seller_data, async_client):
     )
     fake_fio_response.text = general_csv_stream
 
-    inv = await whohas(AsyncMock(), "C", forceUpdate=True)
+    inv, last_updated = await whohas(AsyncMock(), "C", forceUpdate=True)
 
     assert inv[0] == ("Felmer", 250)
     assert inv[1] == ("Kindling", 200)
@@ -68,20 +68,20 @@ async def test_inventory(mock_seller_data, async_client):
 
     ctx = MagicMock()
     ctx.reply = AsyncMock()
-    inv = await whohas(ctx, "C", forceUpdate=True)
+    inv, last_updated = await whohas(ctx, "C", forceUpdate=True)
 
     assert inv[0] == ("Felmer", 250)
     assert inv[1] == ("Kindling", 200)
 
     fake_fio_response.status_code = 200
     fake_fio_response.text = shipyard_csv_stream
-    inv = await whohas(ctx, "WCB", forceUpdate=True)
+    inv, last_updated = await whohas(ctx, "WCB", forceUpdate=True)
 
     assert len(inv) == 1
     assert inv[0] == ("Felmer", 3)
 
     fake_fio_response.status_code = 500
-    inv = await whohas(ctx, "C", forceUpdate=True)
+    inv, last_updated = await whohas(ctx, "C", forceUpdate=True)
 
     assert inv[0] == ("Felmer", 250)
     assert inv[1] == ("Kindling", 200)
@@ -139,14 +139,11 @@ async def test_pos_filter(mock_seller_data, async_client):
 
     async_client.return_value.__aenter__.return_value = http_client
 
-    inv = await whohas(MagicMock(), "C", False, forceUpdate=True)
+    inv, last_updated = await whohas(MagicMock(), "C", False, forceUpdate=True)
 
     assert len(inv) == 2
     assert ("Kindling", 200) in inv
     assert ("Gilith", 100) in inv
-
-
-# TODO: test shouldReturnAll = False
 
 
 @pytest.mark.asyncio

--- a/test/test_inventory.py
+++ b/test/test_inventory.py
@@ -8,9 +8,9 @@ from HAL9666.lib.inventory import getSellerData, whohas
 
 
 @pytest.mark.asyncio
-@patch("HAL9666.lib.inventory.http_client.get")
+@patch("HAL9666.lib.inventory.AsyncClient")
 @patch("HAL9666.lib.inventory.getSellerData")
-async def test_inventory(mock_getSellerData, http_client_get):
+async def test_inventory(mock_getSellerData, async_client):
     general_csv_stream = create_csv(
         [
             {
@@ -30,7 +30,10 @@ async def test_inventory(mock_getSellerData, http_client_get):
     fake_fio_response.status_code = 200
     fake_fio_response.text = general_csv_stream
 
-    http_client_get.return_value = fake_fio_response
+    http_client = MagicMock()
+    http_client.get = AsyncMock(return_value=fake_fio_response)
+
+    async_client.return_value.__aenter__.return_value = http_client
 
     mock_getSellerData.return_value = {"Kindling": [], "Felmer": [], "Gilith": []}
 
@@ -84,9 +87,9 @@ async def test_inventory(mock_getSellerData, http_client_get):
 
 
 @pytest.mark.asyncio
-@patch("HAL9666.lib.inventory.http_client.get")
+@patch("HAL9666.lib.inventory.AsyncClient")
 @patch("HAL9666.lib.inventory.getSellerData")
-async def test_pos_filter(mock_getSellerData, http_client_get):
+async def test_pos_filter(mock_getSellerData, async_client):
     # when someone has set POS filter, we should only count the amounts from those locations
     mock_getSellerData.return_value = {
         "Kindling": ["UV-351a"],
@@ -127,7 +130,10 @@ async def test_pos_filter(mock_getSellerData, http_client_get):
     fio_response.status_code = 200
     fio_response.text = csv_stream
 
-    http_client_get.return_value = fio_response
+    http_client = MagicMock()
+    http_client.get = AsyncMock(return_value=fio_response)
+
+    async_client.return_value.__aenter__.return_value = http_client
 
     inv = await whohas(MagicMock(), "C", False, forceUpdate=True)
 
@@ -137,6 +143,7 @@ async def test_pos_filter(mock_getSellerData, http_client_get):
 
 
 # TODO: test shouldReturnAll = False
+
 
 @pytest.mark.asyncio
 @patch("HAL9666.lib.inventory.http_client.get")

--- a/test/test_inventory.py
+++ b/test/test_inventory.py
@@ -8,9 +8,9 @@ from HAL9666.lib.inventory import getSellerData, whohas
 
 
 @pytest.mark.asyncio
-@patch("HAL9666.lib.inventory.requests.get")
+@patch("HAL9666.lib.inventory.http_client.get")
 @patch("HAL9666.lib.inventory.getSellerData")
-async def test_inventory(mock_getSellerData, requests_get):
+async def test_inventory(mock_getSellerData, http_client_get):
     general_csv_stream = create_csv(
         [
             {
@@ -30,11 +30,11 @@ async def test_inventory(mock_getSellerData, requests_get):
     fake_fio_response.status_code = 200
     fake_fio_response.text = general_csv_stream
 
-    requests_get.return_value = fake_fio_response
+    http_client_get.return_value = fake_fio_response
 
     mock_getSellerData.return_value = {"Kindling": [], "Felmer": [], "Gilith": []}
 
-    inv = await whohas(AsyncMock(), "C")
+    inv = await whohas(AsyncMock(), "C", forceUpdate=True)
     assert inv[0] == ("Kindling", 200)
 
     general_csv_stream = create_csv(
@@ -55,7 +55,7 @@ async def test_inventory(mock_getSellerData, requests_get):
     )
     fake_fio_response.text = general_csv_stream
 
-    inv = await whohas(AsyncMock(), "C")
+    inv = await whohas(AsyncMock(), "C", forceUpdate=True)
 
     assert inv[0] == ("Felmer", 250)
     assert inv[1] == ("Kindling", 200)
@@ -64,29 +64,29 @@ async def test_inventory(mock_getSellerData, requests_get):
 
     ctx = MagicMock()
     ctx.reply = AsyncMock()
-    inv = await whohas(ctx, "C")
+    inv = await whohas(ctx, "C", forceUpdate=True)
 
     assert inv[0] == ("Felmer", 250)
     assert inv[1] == ("Kindling", 200)
 
     fake_fio_response.status_code = 200
     fake_fio_response.text = shipyard_csv_stream
-    inv = await whohas(ctx, "WCB")
+    inv = await whohas(ctx, "WCB", forceUpdate=True)
 
     assert len(inv) == 1
     assert inv[0] == ("Felmer", 3)
 
     fake_fio_response.status_code = 500
-    inv = await whohas(ctx, "C")
+    inv = await whohas(ctx, "C", forceUpdate=True)
 
     assert inv[0] == ("Felmer", 250)
     assert inv[1] == ("Kindling", 200)
 
 
 @pytest.mark.asyncio
-@patch("HAL9666.lib.inventory.requests.get")
+@patch("HAL9666.lib.inventory.http_client.get")
 @patch("HAL9666.lib.inventory.getSellerData")
-async def test_pos_filter(mock_getSellerData, requests_get):
+async def test_pos_filter(mock_getSellerData, http_client_get):
     # when someone has set POS filter, we should only count the amounts from those locations
     mock_getSellerData.return_value = {
         "Kindling": ["UV-351a"],
@@ -127,9 +127,9 @@ async def test_pos_filter(mock_getSellerData, requests_get):
     fio_response.status_code = 200
     fio_response.text = csv_stream
 
-    requests_get.return_value = fio_response
+    http_client_get.return_value = fio_response
 
-    inv = await whohas(MagicMock(), "C", False)
+    inv = await whohas(MagicMock(), "C", False, forceUpdate=True)
 
     assert len(inv) == 2
     assert ("Kindling", 200) in inv
@@ -138,9 +138,9 @@ async def test_pos_filter(mock_getSellerData, requests_get):
 
 # TODO: test shouldReturnAll = False
 
-
-@patch("HAL9666.lib.inventory.requests.get")
-def test_getSellersData(requests_get):
+@pytest.mark.asyncio
+@patch("HAL9666.lib.inventory.http_client.get")
+async def test_getSellersData(http_client_get):
     csv_data = [
         {"MAT": "C", "Seller": "Kindling", "POS": "KW-688c", "Price/u": "300"},
         {"MAT": "C", "Seller": "Felmer", "POS": "", "Price/u": "300"},
@@ -151,14 +151,14 @@ def test_getSellersData(requests_get):
     fake_fio_response = MagicMock()
     fake_fio_response.status_code = 200
     fake_fio_response.text = sheets_csv_stream
-    requests_get.return_value = fake_fio_response
+    http_client_get.return_value = fake_fio_response
 
-    sellers = getSellerData("C")
+    sellers = await getSellerData("C")
 
     assert isinstance(sellers, dict)
     assert len(sellers) == 2
 
-    sellers = getSellerData("WCB")
+    sellers = await getSellerData("WCB")
     assert len(sellers) == 1
 
 


### PR DESCRIPTION
(Builds on top of #12, that should be reviewed first)

1. Added a background fetch of both the FIO data and the Sheets data. Will fetch every 5 mins for now. Use "force" to force an update from $whohas.
2. Added some basic retry functionality when fetching FIO data. We are often getting 429 responses (unintuitively we often get this for the first 2-3 tries after we have waited 5 minutes). We will retry up to 10 times before giving up. Each request has a 5 second timeout now. This, together with the background fetch, should hopefully get rid of the "error updating inventory" spam.
3. Added a "last updated" section at the top of the bot response, to get a feel for if the data is stale.
4. Moved lots of the inventory logic into its own class to try and group related data together. Same for the Sheets data. This can probably be improved a lot still, so see it as a first draft.

Closes #6 (we keep the message for now, but this should be a lot less frequent)
Closes #18 